### PR TITLE
Just a semantic change - $null should be on left

### DIFF
--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -158,7 +158,7 @@ function Get-LatestEZToolsUpdater
         Log -logFilePath $logFilePath -msg 'Updating script to the latest version'
         
         #Start a new powershell process so we can replace the existing file and run the new script
-        Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/Donovoi/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$PSScriptRoot\KAPE-EZToolsAncillaryUpdater.ps1"
+        Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/AndrewRathbun/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$PSScriptRoot\KAPE-EZToolsAncillaryUpdater.ps1"
         Log -logFilePath $logFilePath -msg "Successfully updated script to $CurrentScriptVersionNumber"
         Log -logFilePath $logFilePath -msg 'Starting updated script in new Window'
         Start-Process PowerShell -ArgumentList "$PSScriptRoot\KAPE-EZToolsAncillaryUpdater.ps1 $netVersion $(if ($PSBoundParameters.Keys.Contains('silent')) { $silent = $true })"

--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -141,7 +141,7 @@ function Get-LatestEZToolsUpdater
     param ()
     
     # First check the version of the current script show line number of match
-    $currentScriptVersion = Get-Content $('.\KAPE-EZToolsAncillaryUpdater.ps1') | Select-String -SimpleMatch 'Version:' | Select-Object -First 1
+    $currentScriptVersion = Get-Content $("$PSScriptRoot\KAPE-EZToolsAncillaryUpdater.ps1") | Select-String -SimpleMatch 'Version:' | Select-Object -First 1
     [System.Single]$CurrentScriptVersionNumber = $currentScriptVersion.ToString().Split("`t")[2]
     Log -logFilePath $logFilePath -msg "Current script version is $CurrentScriptVersionNumber"
     

--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -137,7 +137,12 @@ function Get-LatestEZToolsUpdater {
     [System.Single]$CurrentScriptVersionNumber = $currentScriptVersion.ToString().Split("`t")[2]
     Log -logFilePath $logFilePath -msg "Current script version is $CurrentScriptVersionNumber"
     
-    # Now get the latest version from the script hosted on github
+   
+    # Remove the temp file if it exist
+    if ( Test-Path "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1") {
+        Remove-Item "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1" -Force
+    }
+     # Now get the latest version from github
     Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/AndrewRathburn/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1"
     $TempUpdateScript = $(Resolve-Path "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1")
     $NewScriptVersion = Get-Content $TempUpdateScript | Select-String -SimpleMatch 'Version:' | Select-Object -First 1

--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -130,9 +130,17 @@ function Get-KAPEUpdateEXE {
 #>
 function Get-LatestEZToolsUpdater {
     [CmdletBinding()]
-    param ()
-    
-    # First check the version of the current script show line number of match
+    param (
+        [Parameter()]
+        [switch]
+        $NoUpdates
+    )
+    # Don't update if $NoUpdates is set to true
+    if ($NoUpdates) {
+        Log -logFilePath $logFilePath -msg "Not Updating script do to `$NoUpdates switch"
+        break
+    }
+    # Check the version of the current script
     $currentScriptVersion = Get-Content $("$PSScriptRoot\KAPE-EZToolsAncillaryUpdater.ps1") | Select-String -SimpleMatch 'Version:' | Select-Object -First 1
     [System.Single]$CurrentScriptVersionNumber = $currentScriptVersion.ToString().Split("`t")[2]
     Log -logFilePath $logFilePath -msg "Current script version is $CurrentScriptVersionNumber"
@@ -142,14 +150,14 @@ function Get-LatestEZToolsUpdater {
     if ( Test-Path "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1") {
         Remove-Item "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1" -Force
     }
-     # Now get the latest version from github
+    # Now get the latest version from github
     Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/AndrewRathburn/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1"
     $TempUpdateScript = $(Resolve-Path "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1")
     $NewScriptVersion = Get-Content $TempUpdateScript | Select-String -SimpleMatch 'Version:' | Select-Object -First 1
     [System.Single]$LatestVersionNumber = $NewScriptVersion.ToString().Split("`t")[2]
     Log -logFilePath $logFilePath -msg "Latest version of this script is $LatestVersionNumber"
     
-    if ($($CurrentScriptVersionNumber -lt $LatestVersionNumber) -and $($NoUpdates -eq $false)) {
+    if ($CurrentScriptVersionNumber -lt $LatestVersionNumber) {
         Log -logFilePath $logFilePath -msg 'Updating script to the latest version'
         
         #Start a new powershell process so we can replace the existing file and run the new script

--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -51,7 +51,7 @@
         Organization: 	Kroll
         Filename:		KAPE-EZToolsAncillaryUpdater.ps1
         GitHub:			https://github.com/AndrewRathbun/KAPE-EZToolsAncillaryUpdater
-        Version:		3.2
+        Version:		3.6
         ===========================================================================
 #>
 param
@@ -138,7 +138,7 @@ function Get-LatestEZToolsUpdater {
     Log -logFilePath $logFilePath -msg "Current script version is $CurrentScriptVersionNumber"
     
     # Now get the latest version from the script hosted on github
-    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/AndrewRathbun/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1"
+    Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/AndrewRathburn/KAPE-EZToolsAncillaryUpdater/main/KAPE-EZToolsAncillaryUpdater.ps1' -OutFile "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1"
     $TempUpdateScript = $(Resolve-Path "$ENV:USERPROFILE\KAPE-EZToolsAncillaryUpdater.ps1")
     $NewScriptVersion = Get-Content $TempUpdateScript | Select-String -SimpleMatch 'Version:' | Select-Object -First 1
     [System.Single]$LatestVersionNumber = $NewScriptVersion.ToString().Split("`t")[2]

--- a/KAPE-EZToolsAncillaryUpdater.ps1
+++ b/KAPE-EZToolsAncillaryUpdater.ps1
@@ -153,7 +153,7 @@ function Get-KAPEUpdateEXE
 	
 	$script:getKapeUpdatePs1 = Get-ChildItem -Path $PSScriptRoot -Filter $getKapeUpdatePs1FileName # .\KAPE\Get-KAPEUpdate.ps1
 	
-	if ($getKapeUpdatePs1 -ne $null)
+	if ($null -ne $getKapeUpdatePs1)
 	{
 		Log -logFilePath $logFilePath -msg "Running $getKapeUpdatePs1FileName to update KAPE to the latest binary"
 		try


### PR DESCRIPTION
https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/possibleincorrectcomparisonwithnull?view=ps-modules

cheeky copy/paste

"To ensure that PowerShell performs comparisons correctly, the $null element should be on the left side of the operator.

There are multiple reasons why this occurs:

$null is a scalar value. When the value on the left side of an operator is a scalar, comparison operators return a Boolean value. When the value is a collection, the comparison operators return any matching values or an empty array if there are no matches in the collection.
PowerShell performs type casting left to right, resulting in incorrect comparisons when $null is cast to other scalar types.
The only way to reliably check if a value is $null is to place $null on the left side of the operator so that a scalar comparison is performed."